### PR TITLE
Add CMake support and fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+# CMake version configuration
+cmake_minimum_required(VERSION 3.5...3.19)
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
+
+# Define project
+project(dxflib
+    VERSION 3.26.4
+    LANGUAGES CXX
+)
+
+# Use C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Export library
+add_library(dxflib STATIC
+    # Sources
+    src/dl_dxf.cpp
+    src/dl_writer_ascii.cpp
+
+    # Headers
+    src/dl_attributes.h
+    src/dl_codes.h
+    src/dl_creationadapter.h
+    src/dl_creationinterface.h
+    src/dl_dxf.h
+    src/dl_entities.h
+    src/dl_exception.h
+    src/dl_extrusion.h
+    src/dl_global.h
+    src/dl_writer_ascii.h
+    src/dl_writer.h
+)
+target_include_directories(dxflib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+# Alias to namespaced variant
+add_library(Dxflib::Dxflib ALIAS dxflib)

--- a/src/dl_codes.h
+++ b/src/dl_codes.h
@@ -44,13 +44,6 @@
 #define strcasecmp(s,t) _stricmp(s,t)
 #endif
 
-
-#ifdef _WIN32
-#undef M_PI
-#define M_PI   3.14159265358979323846
-#pragma warning(disable : 4800)
-#endif
-
 #ifndef M_PI
 #define M_PI 3.1415926535897932384626433832795
 #endif

--- a/src/dl_dxf.h
+++ b/src/dl_dxf.h
@@ -39,12 +39,6 @@
 #include "dl_entities.h"
 #include "dl_writer_ascii.h"
 
-#ifdef _WIN32
-#undef M_PI
-#define M_PI   3.14159265358979323846
-#pragma warning(disable : 4800)
-#endif
-
 #ifndef M_PI
 #define M_PI 3.1415926535897932384626433832795
 #endif

--- a/src/dl_extrusion.h
+++ b/src/dl_extrusion.h
@@ -125,7 +125,7 @@ public:
     /**
      * Copies extrusion (deep copies) from another extrusion object.
      */
-    DL_Extrusion operator = (const DL_Extrusion& extru) {
+    DL_Extrusion& operator = (const DL_Extrusion& extru) {
         setDirection(extru.direction[0], extru.direction[1], extru.direction[2]);
         setElevation(extru.elevation);
 


### PR DESCRIPTION
The compiler warnings occur in header files and thus also appear when compiling LibrePCB, so I think we have to fix them here.

The CMake file is copy&pasted, hopefully it's more or less correct :see_no_evil: 